### PR TITLE
Update installation instructions to opam2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "01-install-ocaml"]
 	path = 01-install-ocaml
-	url = https://github.com/janestreet/install-ocaml
+	url = https://github.com/dra27/install-ocaml


### PR DESCRIPTION
PR opened upstream for the install-ocaml repo, but just switched this to my own fork for now.