### PR TITLE
Tweaks to exercises

### DIFF
--- a/02-exercises/06-pattern-matching/problem.ml
+++ b/02-exercises/06-pattern-matching/problem.ml
@@ -31,7 +31,7 @@ let%test "Testing non_zero..." = Bool.( = ) true (non_zero (-400))
    non-zero by matching on both of them. *)
 let both_non_zero x y = failwith "For you to implement"
 
-let%test "Testing both_positive..." = Bool.( = ) false (both_non_zero 0 0)
-let%test "Testing both_positive..." = Bool.( = ) false (both_non_zero 0 1)
-let%test "Testing both_positive..." = Bool.( = ) false (both_non_zero (-20) 0)
-let%test "Testing both_positive..." = Bool.( = ) true (both_non_zero 400 (-5))
+let%test "Testing both_non_zero..." = Bool.( = ) false (both_non_zero 0 0)
+let%test "Testing both_non_zero..." = Bool.( = ) false (both_non_zero 0 1)
+let%test "Testing both_non_zero..." = Bool.( = ) false (both_non_zero (-20) 0)
+let%test "Testing both_non_zero..." = Bool.( = ) true (both_non_zero 400 (-5))

--- a/README.org
+++ b/README.org
@@ -10,7 +10,7 @@ developing in OCaml.
   OCaml. Each one has some expect-tests embedded in it. The workflow is:
 
   #+BEGIN_SRC bash
-  cd problems/$problem_dir
+  cd 02-exercises/$problem_dir
 
   dune runtest # builds and runs inline tests
   # Look at test output and compiler errors, edit problem.ml, rerun:


### PR DESCRIPTION
README refers to the wrong directory and I happened to notice a wrong function name in a test, owing to a typo on my part 🙂 

I had one Base-related question - what is the correct Base way of saying `Caml.print_int`? That felt like it might be worth more of a hint, unless I skipped over something...